### PR TITLE
Handle duplicate images and link rules to hosts

### DIFF
--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -37,3 +37,16 @@ CREATE TABLE IF NOT EXISTS pending_reviews (
     entity_id INTEGER NOT NULL,
     differences JSONB
 );
+
+CREATE TABLE IF NOT EXISTS weapon_hosts (
+    weapon_id INTEGER REFERENCES weapons(id),
+    host_type TEXT NOT NULL,
+    host_id INTEGER NOT NULL,
+    PRIMARY KEY (weapon_id, host_type, host_id)
+);
+
+CREATE TABLE IF NOT EXISTS unit_special_rules (
+    unit_id INTEGER REFERENCES units(id),
+    special_rule_id INTEGER REFERENCES special_rules(id),
+    PRIMARY KEY (unit_id, special_rule_id)
+);

--- a/python_service/tests/test_harvest.py
+++ b/python_service/tests/test_harvest.py
@@ -1,6 +1,30 @@
+import hashlib
+
 from python_service.app import harvest
 
 
 def test_run_returns_empty_for_empty_dir(tmp_path):
     imgs = harvest.run(tmp_path)
     assert imgs == []
+
+
+def test_run_deduplicates_images(tmp_path):
+    img1 = tmp_path / "a.png"
+    img1.write_bytes(b"same")
+    img2 = tmp_path / "b.png"
+    img2.write_bytes(b"same")
+    img3 = tmp_path / "c.png"
+    img3.write_bytes(b"unique")
+
+    imgs = harvest.run(tmp_path)
+
+    assert len(imgs) == 2
+    paths = {img.path for img in imgs}
+    assert str(img3) in paths
+    assert (str(img1) in paths) ^ (str(img2) in paths)
+
+    expected_digests = {
+        hashlib.md5(b"same").hexdigest(),
+        hashlib.md5(b"unique").hexdigest(),
+    }
+    assert {img.digest for img in imgs} == expected_digests


### PR DESCRIPTION
## Summary
- Ignore duplicate image files during harvest to prevent processing the same rules multiple times
- Return content hashes for unique images so we can track already ingested rules
- Add database tables linking weapons to their hosts and special rules to units
- Test deduplication behaviour of the harvester

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cbd4992d08320a80f30c8269c5880