### PR TITLE
Integrate OCR extraction in harvest step

### DIFF
--- a/python_service/app/harvest.py
+++ b/python_service/app/harvest.py
@@ -5,13 +5,17 @@ from pathlib import Path
 from typing import List
 import hashlib
 
+from . import ocr_service
+
 
 @dataclass(frozen=True)
 class HarvestedImage:
-    """Metadata about a harvested image."""
+    """Metadata about a harvested image and its extracted text."""
 
     path: str
     digest: str
+    text: str
+    is_legion_rule: bool
 
 
 def run(directory: str) -> List[HarvestedImage]:
@@ -31,8 +35,10 @@ def run(directory: str) -> List[HarvestedImage]:
         digest = hashlib.md5(p.read_bytes()).hexdigest()
         if digest in seen_hashes:
             continue
+        text = ocr_service.extract_text(str(p))
+        is_legion_rule = "legion" in text.lower()
         seen_hashes.add(digest)
-        unique_files.append(HarvestedImage(str(p), digest))
+        unique_files.append(HarvestedImage(str(p), digest, text, is_legion_rule))
     return unique_files
 
 

--- a/python_service/tests/test_harvest.py
+++ b/python_service/tests/test_harvest.py
@@ -1,5 +1,7 @@
 import hashlib
 
+from pathlib import Path
+
 from python_service.app import harvest
 
 
@@ -8,13 +10,22 @@ def test_run_returns_empty_for_empty_dir(tmp_path):
     assert imgs == []
 
 
-def test_run_deduplicates_images(tmp_path):
+def test_run_deduplicates_images(tmp_path, monkeypatch):
     img1 = tmp_path / "a.png"
     img1.write_bytes(b"same")
     img2 = tmp_path / "b.png"
     img2.write_bytes(b"same")
     img3 = tmp_path / "c.png"
     img3.write_bytes(b"unique")
+
+    # stub out OCR so tests don't depend on an external engine
+    def fake_ocr(path):
+        name = Path(path).name
+        if name == "c.png":
+            return "Legion rules for the XVI Legion"
+        return f"text from {name}"
+
+    monkeypatch.setattr(harvest.ocr_service, "extract_text", fake_ocr)
 
     imgs = harvest.run(tmp_path)
 
@@ -28,3 +39,10 @@ def test_run_deduplicates_images(tmp_path):
         hashlib.md5(b"unique").hexdigest(),
     }
     assert {img.digest for img in imgs} == expected_digests
+
+    img_map = {img.path: img for img in imgs}
+    assert img_map[str(img3)].is_legion_rule is True
+    assert img_map[str(img3)].text == "Legion rules for the XVI Legion"
+    for path, img in img_map.items():
+        if path != str(img3):
+            assert img.is_legion_rule is False


### PR DESCRIPTION
## Summary
- Extend harvester to call OCR on each unique image and capture extracted text
- Tag harvested pages as legion rules when OCR text mentions a legion
- Update tests to stub OCR and verify legion rule detection

## Testing
- `pytest -q`
- `cargo test --manifest-path rust_service/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_689ccb738234832093fd53ffb859d218