### PR TITLE
fix: makefile portability for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
-.RECIPEPREFIX := >
 .PHONY: up down test harvest build
 
 up:
-> docker compose up -d
+	docker compose up -d
 
 down:
-> docker compose down
+	docker compose down
 
 harvest:
-> python python_service/app/harvest.py $(DIR)
+	python python_service/app/harvest.py $(DIR)
 
 test:
-> cargo test --manifest-path rust_service/Cargo.toml
-> pytest python_service/tests
+	cargo test --manifest-path rust_service/Cargo.toml
+	pytest python_service/tests
 
 build:
-> docker compose build
+	docker compose build


### PR DESCRIPTION
## Summary
- use default tab recipe prefix instead of GNU-specific `.RECIPEPREFIX`

## Testing
- `make build` *(fails: docker: No such file or directory)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cf9f58780832095252cbf688313cc