### PR TITLE
Skip non-image files and ignore sample data in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+sample_data/

--- a/python_service/app/harvest.py
+++ b/python_service/app/harvest.py
@@ -29,8 +29,9 @@ def run(directory: str) -> List[HarvestedImage]:
     path = Path(directory)
     seen_hashes = set()
     unique_files: List[HarvestedImage] = []
+    supported_exts = {".jpg", ".jpeg", ".png"}
     for p in path.glob("*"):
-        if not p.is_file():
+        if not p.is_file() or p.suffix.lower() not in supported_exts:
             continue
         digest = hashlib.md5(p.read_bytes()).hexdigest()
         if digest in seen_hashes:

--- a/python_service/tests/test_harvest.py
+++ b/python_service/tests/test_harvest.py
@@ -46,3 +46,17 @@ def test_run_deduplicates_images(tmp_path, monkeypatch):
     for path, img in img_map.items():
         if path != str(img3):
             assert img.is_legion_rule is False
+
+
+def test_run_skips_non_image_files(tmp_path, monkeypatch):
+    txt = tmp_path / "note.txt"
+    txt.write_text("not an image")
+
+    def fake_ocr(_):
+        raise AssertionError("OCR should not run on non-images")
+
+    monkeypatch.setattr(harvest.ocr_service, "extract_text", fake_ocr)
+
+    imgs = harvest.run(tmp_path)
+
+    assert imgs == []


### PR DESCRIPTION
## Summary
- process only JPEG/PNG files during harvesting to avoid running OCR on videos or other files
- skip shipping `sample_data` to the Docker daemon so builds stay fast

## Testing
- `make test`
- `make build` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_689d00c0a624832083fae2af5bb353c5